### PR TITLE
release: PyPI publish workflow + Docker for v0.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish to PyPI
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY pyproject.toml README.md ./
 COPY dkb_runtime ./dkb_runtime
 COPY alembic.ini ./
@@ -18,8 +13,8 @@ COPY schema ./schema
 COPY config ./config
 COPY scripts ./scripts
 
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "dkb_runtime.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "dkb_runtime.api.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,14 @@ services:
       - postgres
     env_file:
       - .env
+    environment:
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-dkb}:${POSTGRES_PASSWORD:-dkb}@postgres:5432/${POSTGRES_DB:-dkb}
     ports:
       - "8000:8000"
     command: >
       sh -c "alembic upgrade head &&
              python scripts/load_seed.py &&
-             uvicorn dkb_runtime.main:app --host 0.0.0.0 --port 8000"
+             uvicorn dkb_runtime.api.app:app --host 0.0.0.0 --port 8000"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Closes #16
Closes #17

## Summary
- Added PyPI publish workflow (.github/workflows/publish.yml)
- Finalized Dockerfile and docker-compose.yml
- Ready for v0.1.0 tag

## Test Plan
- [ ] `docker compose up` starts API + PostgreSQL
- [ ] `python -m build` produces wheel
- [ ] Tag push triggers publish workflow

Made with [Cursor](https://cursor.com)