### PR TITLE
feat(ci): downstream dispatch + README CI badge

### DIFF
--- a/.github/workflows/cross-repo-notify.yml
+++ b/.github/workflows/cross-repo-notify.yml
@@ -1,0 +1,21 @@
+name: Cross-repo CI notify
+on:
+  push:
+    branches: [master]
+
+jobs:
+  dispatch-downstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch ai-store-dkb
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          repository: songblaq/ai-store-dkb
+          event-type: dkb-upstream-trigger
+      - name: Dispatch agent-prompt-dkb
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          repository: songblaq/agent-prompt-dkb
+          event-type: dkb-upstream-trigger

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/songblaq/dkb-runtime/actions/workflows/ci.yml/badge.svg)
+
 # dkb-runtime
 
 DKB(Directive Knowledge Base) 명세를 구현한 **설치 가능한 Python 패키지**.


### PR DESCRIPTION
Part of songblaq/directive-knowledge-base#10.

- `cross-repo-notify.yml`: on push to `master`, dispatch `dkb-upstream-trigger` to ai-store-dkb and agent-prompt-dkb.
- README CI badge.

Requires `CROSS_REPO_DISPATCH_TOKEN` repository secret (PAT with access to downstream repos).

Made with [Cursor](https://cursor.com)